### PR TITLE
chore(ci): change postgres user and host envars

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -37,10 +37,6 @@ on:
         description: Database PVC size; e.g. 1Gi
         default: "128Mi"
         type: string
-      test:
-        description: Run in test mode?
-        default: true
-        type: boolean
       test-mode:
         description: Test only?
         default: true
@@ -127,8 +123,7 @@ jobs:
 
   run-etl:
     name: Run ETL
-    environment: ${{ inputs.environment }}
-    if: inputs.test == true
+    if: github.event.name == 'pull_request'
     needs: deploy
     runs-on: ubuntu-24.04
     timeout-minutes: 5

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -107,6 +107,8 @@ jobs:
               -p TAG=${{ inputs.tag }}
               -p TEST_MODE=${{ inputs.test-mode }}
               -p POSTGRES_HOST=${{ inputs.postgres-host }}
+              -p POSTGRES_DB=nr-spar
+              -p POSTGRES_USER=nr-spar
             repository: ${{ github.repository }}
     steps:
       - uses: bcgov/action-deployer-openshift@v3.2.0

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -107,8 +107,8 @@ jobs:
               -p TAG=${{ inputs.tag }}
               -p TEST_MODE=${{ inputs.test-mode }}
               -p POSTGRES_HOST=${{ inputs.postgres-host }}
-              -p POSTGRES_DB=nr-spar
-              -p POSTGRES_USER=nr-spar
+              -p POSTGRES_DB=${{ github.event.name == 'pull_request' && 'nr-fds-pyetl' || 'nr-spar' }}
+              -p POSTGRES_USER=${{ github.event.name == 'pull_request' && 'nr-fds-pyetl' || 'nr-spar' }}
             repository: ${{ github.repository }}
     steps:
       - uses: bcgov/action-deployer-openshift@v3.2.0

--- a/sync/openshift.deploy.yml
+++ b/sync/openshift.deploy.yml
@@ -105,9 +105,9 @@ objects:
                           name: ${REPO}-${ZONE}-${APP}
                           key: oracle-sync-user
                     - name: POSTGRES_DB
-                      value: ${POSTGRES_DB}
-                    - name: POSTGRES_HOST
                       value: ${REPO}
+                    - name: POSTGRES_HOST
+                      value: ${POSTGRES_HOST}
                     - name: POSTGRES_PASSWORD
                       valueFrom:
                         secretKeyRef:

--- a/sync/openshift.deploy.yml
+++ b/sync/openshift.deploy.yml
@@ -11,6 +11,12 @@ parameters:
   - name: POSTGRES_HOST
     description: PostgreSQL database host
     required: true
+  - name: POSTGRES_DB
+    description: PostgreSQL database name
+    required: true
+  - name: POSTGRES_USER
+    description: PostgreSQL database user
+    value: "nr-spar"
 
   ### Recommended - suggest hard coding
   - name: APP
@@ -105,24 +111,18 @@ objects:
                           name: ${REPO}-${ZONE}-${APP}
                           key: oracle-sync-user
                     - name: POSTGRES_DB
-                      valueFrom:
-                        secretKeyRef:
-                          name: ${REPO}-${ZONE}-database
-                          key: database-name
+                      value: ${POSTGRES_DB}
                     - name: POSTGRES_HOST
                       value: ${POSTGRES_HOST}
                     - name: POSTGRES_PASSWORD
-                      valueFrom:
-                        secretKeyRef:
-                          name: ${REPO}-${ZONE}-database
-                          key: database-password
+                      value: ${POSTGRES_PASSWORD}
                     - name: POSTGRES_PORT
                       valueFrom:
                         secretKeyRef:
                           name: ${REPO}-${ZONE}-database
                           key: database-port
                     - name: POSTGRES_USER
-                      value: ${REPO}
+                      value: ${POSTGRES_USER}
                   resources:
                     requests:
                       cpu: 50m

--- a/sync/openshift.deploy.yml
+++ b/sync/openshift.deploy.yml
@@ -105,12 +105,9 @@ objects:
                           name: ${REPO}-${ZONE}-${APP}
                           key: oracle-sync-user
                     - name: POSTGRES_DB
-                      valueFrom:
-                        secretKeyRef:
-                          name: ${REPO}-${ZONE}-database
-                          key: database-name
+                      value: ${POSTGRES_DB}
                     - name: POSTGRES_HOST
-                      value: ${POSTGRES_HOST}
+                      value: ${REPO}
                     - name: POSTGRES_PASSWORD
                       valueFrom:
                         secretKeyRef:
@@ -122,10 +119,7 @@ objects:
                           name: ${REPO}-${ZONE}-database
                           key: database-port
                     - name: POSTGRES_USER
-                      valueFrom:
-                        secretKeyRef:
-                          name: ${REPO}-${ZONE}-database
-                          key: database-user
+                      value: ${REPO}
                   resources:
                     requests:
                       cpu: 50m

--- a/sync/openshift.deploy.yml
+++ b/sync/openshift.deploy.yml
@@ -105,7 +105,10 @@ objects:
                           name: ${REPO}-${ZONE}-${APP}
                           key: oracle-sync-user
                     - name: POSTGRES_DB
-                      value: ${REPO}
+                      valueFrom:
+                        secretKeyRef:
+                          name: ${REPO}-${ZONE}-database
+                          key: database-name
                     - name: POSTGRES_HOST
                       value: ${POSTGRES_HOST}
                     - name: POSTGRES_PASSWORD


### PR DESCRIPTION
Modification to templates to allow us to use bcgov/nr-spar templates and stay in line with them.  Sync deployment template has an override for POSTGRES_USER and POSTGRES_DB, since we shouldn't be making upstream changes.

---

Thanks for the PR!

Deployments, as required, will be available below:
- This application will be run as a [GitHub Action](https://github.com/bcgov/nr-fds-pyetl/actions)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-fds-pyetl/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-fds-pyetl/actions/workflows/merge.yml)