### PR TITLE
chore(ci): disable test-mode for PROD

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -46,7 +46,7 @@ jobs:
       secrets-from: nr-spar-prod
       tag: ${{ needs.init.outputs.pr }}
       target: prod
-      test-mode: true
+      test-mode: false
 
   promote:
     name: Promote Images


### PR DESCRIPTION
Please approve/merge once we're sure `TEST_MODE=false` should be set in PROD!

Should be merged around the same time as https://github.com/bcgov/nr-spar/pull/1950.

---

Thanks for the PR!

Deployments, as required, will be available below:
- This application will be run as a [GitHub Action](https://github.com/bcgov/nr-fds-pyetl/actions)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-fds-pyetl/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-fds-pyetl/actions/workflows/merge.yml)