### PR TITLE
feat: improve detection of already RUNNING job

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -90,7 +90,7 @@ jobs:
             -p TAG=${{ inputs.tag }}
             -p TEST_MODE=${{ inputs.test-mode }}
             -p SECRETS_FROM=${{ inputs.secrets-from }}
-          timeout: 5
+          timeout: 5m
           triggers: ${{ inputs.triggers }}
 
   etl-run:

--- a/sync/openshift.deploy.yml
+++ b/sync/openshift.deploy.yml
@@ -137,7 +137,7 @@ objects:
                   imagePullPolicy: Always
               restartPolicy: Never
               terminationGracePeriodSeconds: 30
-              activeDeadlineSeconds: 1600
+              activeDeadlineSeconds: 3600
               dnsPolicy: ClusterFirst
               serviceAccountName: pipeline
               schedulerName: default-scheduler

--- a/sync/src/module/data_sync_control.py
+++ b/sync/src/module/data_sync_control.py
@@ -48,7 +48,7 @@ def get_scheduler(track_db_conn: object, database_schema: str) -> list:
             CURRENT_TIMESTAMP as current_end_time,
             (select run_status
                from spar.etl_execution_log
-              order by from_timestamp desc
+              order by created_at desc
               limit 1) as last_run_status
         from {database_schema}.etl_execution_log
         where run_status = 'SUCCESS' """


### PR DESCRIPTION
improve detection of already RUNNING job (query) and adjust timeout on deploy to 1 hour.

---

Thanks for the PR!

Deployments, as required, will be available below:
- This application will be run as a [GitHub Action](https://github.com/bcgov/nr-fds-pyetl/actions)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-fds-pyetl/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-fds-pyetl/actions/workflows/merge.yml)