### PR TITLE
fix: remove deprecated MS Teams notification from ETL workflows

### DIFF
--- a/.github/workflows/etl-prod.yml
+++ b/.github/workflows/etl-prod.yml
@@ -20,4 +20,4 @@ jobs:
           oc_server: ${{ vars.OC_SERVER }}
           oc_token: ${{ secrets.OC_TOKEN }}
           timeout: 10
-          commands: ./sync/oc_run.sh prod ${{ secrets.oc_token }}
+          commands: ./sync/oc_run.sh prod ${{ secrets.OC_TOKEN }}

--- a/.github/workflows/etl-prod.yml
+++ b/.github/workflows/etl-prod.yml
@@ -21,15 +21,3 @@ jobs:
           oc_token: ${{ secrets.OC_TOKEN }}
           timeout: 10
           commands: ./sync/oc_run.sh prod ${{ secrets.oc_token }}
-
-      - uses: simbo/msteams-message-card-action@latest
-        name: Notify Microsoft Teams
-        if: always() # this ensures it runs even if earlier steps fail
-        with:
-          webhook: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
-          title: "Spar ETL Sync Job status - (env=PROD)"
-          message: |
-            Workflow `${{ github.workflow }}` on `${{ github.repository }}` \
-            Completed with status: **${{ job.status }}** \
-            View run [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          color: ${{ job.status == 'success' && '00FF00' || 'FF0000' }}

--- a/.github/workflows/etl-test.yml
+++ b/.github/workflows/etl-test.yml
@@ -20,4 +20,4 @@ jobs:
           oc_server: ${{ vars.OC_SERVER }}
           oc_token: ${{ secrets.OC_TOKEN }}
           timeout: 60
-          commands: ./sync/oc_run.sh test ${{ secrets.oc_token }}
+          commands: ./sync/oc_run.sh test ${{ secrets.OC_TOKEN }}

--- a/.github/workflows/etl-test.yml
+++ b/.github/workflows/etl-test.yml
@@ -21,15 +21,3 @@ jobs:
           oc_token: ${{ secrets.OC_TOKEN }}
           timeout: 60
           commands: ./sync/oc_run.sh test ${{ secrets.oc_token }}
-
-      - uses: simbo/msteams-message-card-action@latest
-        name: Notify Microsoft Teams
-        if: always() # this ensures it runs even if earlier steps fail
-        with:
-          webhook: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
-          title: "Spar ETL Sync Job status - (env=TEST)"
-          message: |
-            Workflow `${{ github.workflow }}` on `${{ github.repository }}` \
-            Completed with status: **${{ job.status }}** \
-            View run [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          color: ${{ job.status == 'success' && '00FF00' || 'FF0000' }}


### PR DESCRIPTION
## Summary

Removes the `simbo/msteams-message-card-action` step from `etl-prod.yml` and `etl-test.yml`. OCIO/CITZ deprecated O365 connector webhooks, so this step has been failing on every TEST and PROD ETL run and cannot be fixed on our side.

Resolves bcgov/nr-spar#2495 (cross-repo — close the issue manually after merge).

## Notes for reviewers

- After this change, scheduled ETL failures will only surface via GitHub's default scheduled-workflow failure email (sent to the last committer of the workflow file). If the team wants active alerting again, a follow-up ticket for a replacement channel (e.g. Teams Workflows app webhook) is recommended.
- The `MS_TEAMS_WEBHOOK_URI` repo secret is now unused and can be deleted.

## Acceptance Criteria

- [x] Remove code from prod etl
- [x] Remove code from test etl

---

Thanks for the PR!

Deployments, as required, will be available below:
- This application will be run as a [GitHub Action](https://github.com/bcgov/nr-fds-pyetl/actions)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-fds-pyetl/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-fds-pyetl/actions/workflows/merge.yml)